### PR TITLE
🧼 chore: replace NODEBLOCKS_DEV_TOKEN BASALDEV_AUTH_TOKEN again

### DIFF
--- a/.templates/auth/.npmrc
+++ b/.templates/auth/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/catalog/.npmrc
+++ b/.templates/catalog/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/chat/.npmrc
+++ b/.templates/chat/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/notification/.npmrc
+++ b/.templates/notification/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/order/.npmrc
+++ b/.templates/order/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/organization/.npmrc
+++ b/.templates/organization/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/review/.npmrc
+++ b/.templates/review/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/.templates/user/.npmrc
+++ b/.templates/user/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODEBLOCKS_DEV_TOKEN}
+//registry.npmjs.org/:_authToken=${BASALDEV_AUTH_TOKEN}

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ You will need a `npm auth token` in order to access these packages.
 Please prepare this token using the steps below before continuing with setup.
 
 1. Ask Nodeblocks team for a valid `npm auth token`.
-1. Add the token as `NODEBLOCKS_DEV_TOKEN` to your local environment - `.zshrc` `.bashrc` etc
+1. Add the token as `BASALDEV_AUTH_TOKEN` to your local environment - `.zshrc` `.bashrc` etc
 
 ```bash
-export NODEBLOCKS_DEV_TOKEN=__INSERT_YOUR_TOKEN_HERE__
+export BASALDEV_AUTH_TOKEN=__INSERT_YOUR_TOKEN_HERE__
 ```
 
 ### Create a new repository for the custom adapter


### PR DESCRIPTION
Change back NODEBLOCKS_DEV_TOKEN to BASALDEV_AUTH_TOKEN to align with the npm token variable name used in the service